### PR TITLE
Fix(CI): added skip directive for deepsource JS-0128

### DIFF
--- a/scripts/script.js
+++ b/scripts/script.js
@@ -402,7 +402,7 @@ function lineIntersects(rayOrigin, direction, mirror) {
     return { p: false, dist: Infinity, dir: direction }
 }
 
-function undo() {
+function undo() { // skipcq: JS-0128
     lastItem = opticsHistory.pop()
     if (lastItem instanceof Laser)
         lights.pop()
@@ -412,7 +412,7 @@ function undo() {
     updateSim()
 }
 
-function clearAll() {
+function clearAll() { // skipcq: JS-0128
     opticsHistory = []
     lights = []
     rays = []


### PR DESCRIPTION
This is regarding the recent two false positive report submitted.
This is intentional behavior and not a false positive
As you mentioned in the comment of the report that it is being used in HTML. So it is better to skip those lines.